### PR TITLE
Fixed Google documentation Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Description
 Google Maps widget with traffic layer for HABpanel (Openhab).
 
-Get your Goolge Maps API key [here](https://developers.google.com/maps/documentation/javascript/get-api-key1).
+Get your Goolge Maps API key [here](https://developers.google.com/maps/documentation/javascript/get-api-key).
 
 ## Installation
 - Import the downloaded widget to your HABpanel.


### PR DESCRIPTION
Just a small ink fix, since the currently used throws a 404 error